### PR TITLE
Use MAC address when SoC serial cannot be obtained

### DIFF
--- a/airnav_sk.c
+++ b/airnav_sk.c
@@ -31,8 +31,8 @@ int sendKey(void) {
             memset(cserial, 0, 60);
             sprintf(cserial, "%016llx", cpuserial);
         } else {
-            airnav_log("CPU Serial empty.\n");
-            return 0;
+            cserial = net_get_mac_address(0);
+            airnav_log("CPU Serial empty. Use MAC address instead.\n");
         }
     } else if (client_type == CLIENT_TYPE__PC_X64 || client_type == CLIENT_TYPE__PC_X86) {
         cserial = net_get_mac_address(0);
@@ -105,7 +105,8 @@ int sendKeyRequest(void) {
             memset(cserial, 0, 60);
             sprintf(cserial, "%016llx", cpuserial);
         } else {
-            airnav_log("CPU Serial empty.\n");
+            cserial = net_get_mac_address(0);
+            airnav_log("CPU Serial empty. Use MAC address instead.\n");
         }
 
     } else if (client_type == CLIENT_TYPE__PC_X64 || client_type == CLIENT_TYPE__PC_X86) {


### PR DESCRIPTION
On some Raspberry Pi kernels (such as Arch Linux ARM aarch64), rbfeeder does not work properly because there is no serial in the output of /proc/cpuinfo.
This PR uses the MAC address instead if the SoC serial cannot be obtained.

/proc/cpuinfo
```
processor       : 0
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

processor       : 1
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

processor       : 2
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

processor       : 3
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

```

uname -a
```
Linux rabbit 5.16.13-1-aarch64-ARCH #1 SMP Thu Mar 10 01:59:18 UTC 2022 aarch64 GNU/Linux
```