### PR TITLE
Default to the MAC address if Raspberry Pi serial number unavailable

### DIFF
--- a/airnav_sk.c
+++ b/airnav_sk.c
@@ -31,8 +31,7 @@ int sendKey(void) {
             memset(cserial, 0, 60);
             sprintf(cserial, "%016llx", cpuserial);
         } else {
-            airnav_log("CPU Serial empty.\n");
-            return 0;
+            cserial = net_get_mac_address(0);
         }
     } else if (client_type == CLIENT_TYPE__PC_X64 || client_type == CLIENT_TYPE__PC_X86) {
         cserial = net_get_mac_address(0);
@@ -105,7 +104,7 @@ int sendKeyRequest(void) {
             memset(cserial, 0, 60);
             sprintf(cserial, "%016llx", cpuserial);
         } else {
-            airnav_log("CPU Serial empty.\n");
+            cserial = net_get_mac_address(0);
         }
 
     } else if (client_type == CLIENT_TYPE__PC_X64 || client_type == CLIENT_TYPE__PC_X86) {


### PR DESCRIPTION
I have managed to find a Raspberry Pi setup in which the serial number is not available, as a result it wasn't possible to use `rbfeeder` at all. With this patch in place we default to the MAC number whenever it happens.